### PR TITLE
Move translation routes

### DIFF
--- a/api/translations.py
+++ b/api/translations.py
@@ -1,0 +1,53 @@
+import dotenv
+from fastapi import APIRouter
+import requests
+
+router = APIRouter(prefix="/api/translations", tags=["translations"])
+host = "deep-translate1.p.rapidapi.com"
+api_key = dotenv.get_key(".env", "API_KEY")
+headers = {
+    "x-rapidapi-host": host,
+    "x-rapidapi-key": api_key,
+    "content-type": "application/json",
+}
+
+payload = {
+    "q": "Hello, world!",
+    "source": "en",
+    "target": "es"
+}
+
+
+@router.get("/{src_text}/{src_lang}/{target_lang}")
+async def translate(src_text, src_lang, target_lang):
+    """Translate text from one language to another"""
+    url = f"https://{host}/language/translate/v2"
+    querystring = {"q": src_text, "target": target_lang, "source": "en"}
+    response = requests.request("POST", url, headers=headers, json=querystring)
+
+    translation_container = response.json()["data"]["translations"]
+    translation = translation_container
+
+    translation_response = {
+        "sourceText": src_text,
+        "sourceLanguage": src_lang,
+        "translatedText": translation["translatedText"],
+        "targetLanguage": target_lang,
+    }
+
+    return translation_response
+
+
+@router.get("/languages")
+async def get_languages():
+    # url = f"https://{host}/language/translate/v2/languages"
+    # response = requests.request("GET", url, headers=headers)
+    # filter the response to only return english and japanese
+
+    # languages = response.json()["languages"]
+    # languages = [lang for lang in languages if lang["language"] in ["en", "ja"]]
+    # Calling the deep-translate API to get a list of languages is costly, so we'll just return English and Japanese
+    # until I figure out whether I want to cache the results or save them in a MongoDB collection
+
+    languages = [{"language": "en", "name": "English"}, {"language": "ja", "name": "Japanese"}]
+    return languages

--- a/main.py
+++ b/main.py
@@ -1,64 +1,18 @@
-import dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import requests
 from api.cards import router as cards_router
 from api.lessons import router as lessons_router
+from api.translations import router as translations_router
 
 app = FastAPI()
 app.include_router(cards_router)
 app.include_router(lessons_router)
+app.include_router(translations_router)
 origins = ["http://localhost:3000"]
 app.add_middleware(CORSMiddleware, allow_origins=origins, allow_methods=["*"])
-
-host = "deep-translate1.p.rapidapi.com"
-api_key = dotenv.get_key(".env", "API_KEY")
-headers = {
-    "x-rapidapi-host": host,
-    "x-rapidapi-key": api_key,
-    "content-type": "application/json",
-}
-
-payload = {
-    "q": "Hello, world!",
-    "source": "en",
-    "target": "es"
-}
-
 
 @app.get("/")
 async def root():
     return {"message": "Hello World"}
 
 
-# write a function to call the API
-@app.get("/translate/{src_text}/{src_lang}/{target_lang}")
-async def translate(src_text, src_lang, target_lang):
-
-    url = f"https://{host}/language/translate/v2"
-    querystring = {"q": src_text, "target": target_lang, "source": "en"}
-    response = requests.request("POST", url, headers=headers, json=querystring)
-
-    translation_container = response.json()["data"]["translations"]
-    translation = translation_container
-
-    translation_response = {
-        "sourceText": src_text,
-        "sourceLanguage": src_lang,
-        "translatedText": translation["translatedText"],
-        "targetLanguage": target_lang,
-    }
-
-    return translation_response
-
-
-# write a function to call the "/languages" endpoint and return a list of languages
-@app.get("/languages")
-async def get_languages():
-    # url = f"https://{host}/language/translate/v2/languages"
-    # response = requests.request("GET", url, headers=headers)
-    # # filter the response to only return english and japanese
-    # languages = response.json()["languages"]
-    # languages = [lang for lang in languages if lang["language"] in ["en", "ja"]]
-    languages = [{"language": "en", "name": "English"}, {"language": "ja", "name": "Japanese"}]
-    return languages


### PR DESCRIPTION
In this branch, I moved all of the translation related routes into its own file, located in the `api/translations.py` file. 