### PR TITLE
Overhaul models to auto encode properly

### DIFF
--- a/api/cards.py
+++ b/api/cards.py
@@ -32,9 +32,8 @@ async def create_card(card: Card, current_user: User = Depends(get_current_user)
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     # If we don't encode the card, we run into a problem where the card id is not a string
-    new_card = jsonable_encoder(card)
-
-    card_collection.insert_one(new_card)
+    card_collection.insert_one(card.dict(by_alias=True))
+    new_card = card_collection.find_one({"_id": card.id})
 
     # Update the lessons that the card is in
     if new_card["lesson_ids"]:

--- a/api/cards.py
+++ b/api/cards.py
@@ -57,7 +57,7 @@ async def get_cards_by_lesson(lesson_id: PyObjectId):
     return [Card(**card) for card in cards]
 
 
-@router.put("/update/{card_id}")
+@router.put("/update/{card_id}", response_model=Card)
 async def update_card(card_id: PyObjectId, updated_info: UpdateCard, current_user: User = Depends(get_current_user)):
     """Update a card in the database by id"""
     if not is_admin(current_user):

--- a/api/lessons.py
+++ b/api/lessons.py
@@ -60,16 +60,17 @@ async def update_lesson(lesson_id: PyObjectId, updated_info: UpdateLesson):
     updated_lesson = lesson_collection.find_one({"_id": lesson_id})
 
     # if a card was in the old lesson but not the new lesson, remove the lesson id from the card
-    if old_lesson["cards"]:
-        for card_id in old_lesson["cards"]:
-            if card_id not in updated_lesson["cards"]:
-                card_collection.find_one_and_update({"_id": card_id}, {"$pull": {"lesson_id": lesson_id}})
+    if old_lesson["card_ids"]:
+        for card_id in old_lesson["card_ids"]:
+            if card_id not in updated_lesson["card_ids"]:
+                card_collection.find_one_and_update({"_id": card_id}, {"$pull": {"lesson_ids": lesson_id}})
 
     # If the lesson contains cards, update the cards to reflect the new lesson
-    if updated_lesson["cards"]:
-        for card_id in updated_lesson["cards"]:
+    if updated_lesson["card_ids"]:
+        for card_id in updated_lesson["card_ids"]:
             # add the lesson id to the list of lessons the card is associated with
             card_collection.find_one_and_update({"_id": card_id}, {"$addToSet": {"lesson_id": lesson_id}})
+            card_collection.find_one_and_update({"_id": card_id}, {"$addToSet": {"lesson_ids": lesson_id}})
 
     return Lesson(**updated_lesson)
 

--- a/api/lessons.py
+++ b/api/lessons.py
@@ -1,7 +1,6 @@
 from typing import List
 
 import dotenv
-from fastapi.encoders import jsonable_encoder
 
 from pymongo import MongoClient
 from fastapi import APIRouter, status, HTTPException
@@ -89,4 +88,6 @@ async def delete_lesson(lesson_id: PyObjectId):
     lesson_collection.delete_one({"_id": lesson_id})
 
     # update all cards associated with the lesson to reflect the deletion of the lesson
-    card_collection.update_many({"lesson_id": lesson_id}, {"$pull": {"lesson_id": lesson_id}})
+    card_collection.update_many({"lesson_ids": lesson_id}, {"$pull": {"lesson_ids": lesson_id}})
+
+    section_collection.update_one({"lesson_ids": lesson_id}, {"$pull": {"lesson_ids": lesson_id}})

--- a/api/lessons.py
+++ b/api/lessons.py
@@ -29,10 +29,9 @@ async def get_all_lessons():
 @router.post("/create", status_code=status.HTTP_201_CREATED)
 async def create_lesson(lesson: Lesson):
     """Create a new lesson in the database"""
-    new_lesson = jsonable_encoder(lesson)
 
-    lesson_collection.insert_one(new_lesson)
-
+    lesson_collection.insert_one(lesson.dict(by_alias=True))
+    new_lesson = lesson_collection.find_one({"_id": lesson.id})
     # Update the cards that are in the lesson
     if new_lesson["card_ids"] is not None:
         for card_id in new_lesson["card_ids"]:

--- a/api/sections.py
+++ b/api/sections.py
@@ -5,6 +5,7 @@ from pymongo import MongoClient
 
 from api.users import get_current_user, is_admin
 from models import Section, PyObjectId, User
+from models.update_section import UpdateSection
 
 router = APIRouter(prefix="/api/sections", tags=["Sections"])
 mongo_host = dotenv.get_key(".env", "MONGO_HOST")
@@ -18,8 +19,9 @@ lesson_collection = db['lessons']
 async def create_section(section: Section, current_user: User = Depends(get_current_user)):
     if not is_admin(current_user):
         raise HTTPException(status_code=401, detail="Unauthorized")
-    new_section = jsonable_encoder(section)
-    section_collection.insert_one(new_section)
+
+    section_collection.insert_one(section.dict(by_alias=True))
+    new_section = section_collection.find_one({"_id": section.id})
 
     for lesson_id in new_section["lesson_ids"]:
         lesson_collection.find_one_and_update({"_id": lesson_id}, {"$set": {"section_id": new_section["_id"]}})
@@ -41,13 +43,16 @@ async def get_section(section_id: PyObjectId):
 
 
 @router.put("/update/{section_id}")
-async def update_section(section_id: PyObjectId, updated_info: Section, current_user: User = Depends(get_current_user)):
+async def update_section(section_id: PyObjectId, updated_info: UpdateSection, current_user: User = Depends(get_current_user)):
     if not is_admin(current_user):
         raise HTTPException(status_code=401, detail="Unauthorized")
+
     section_info_to_update = {k: v for k, v in updated_info.dict().items() if v is not None}
     old_section = section_collection.find_one_and_update({"_id": section_id}, {"$set": section_info_to_update})
+
     if old_section is None:
         raise HTTPException(status_code=404, detail="Section not found")
+
     updated_section = section_collection.find_one({"_id": section_id})
 
     for lesson_id in updated_section["lesson_ids"]:
@@ -55,11 +60,11 @@ async def update_section(section_id: PyObjectId, updated_info: Section, current_
 
     return Section(**updated_section)
 
-
 @router.delete("/delete/{section_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_section(section_id: PyObjectId, current_user: User = Depends(get_current_user)):
     if not is_admin(current_user):
         raise HTTPException(status_code=401, detail="Unauthorized")
+
     section_collection.delete_one({"_id": section_id})
 
     lesson_collection.update_many({"section_id": section_id}, {"$unset": {"section_id": ""}})

--- a/api/sections.py
+++ b/api/sections.py
@@ -55,8 +55,13 @@ async def update_section(section_id: PyObjectId, updated_info: UpdateSection, cu
 
     updated_section = section_collection.find_one({"_id": section_id})
 
+    for lesson_id in old_section["lesson_ids"]:
+        if lesson_id not in updated_section["lesson_ids"]:
+            lesson_collection.find_one_and_update({"_id": lesson_id}, {"$unset": {"section_id": ""}})
+
     for lesson_id in updated_section["lesson_ids"]:
-        lesson_collection.find_one_and_update({"_id": lesson_id}, {"$set": {"section_id": updated_section["_id"]}})
+        if lesson_id not in old_section["lesson_ids"]:
+            lesson_collection.find_one_and_update({"_id": lesson_id}, {"$set": {"section_id": updated_section["_id"]}})
 
     return Section(**updated_section)
 

--- a/api/users.py
+++ b/api/users.py
@@ -1,5 +1,4 @@
 import dotenv
-from bson import ObjectId
 from fastapi.encoders import jsonable_encoder
 from passlib.context import CryptContext
 
@@ -66,7 +65,7 @@ async def get_current_user(current_user: User = Depends(get_current_user)):
 
 
 @router.get("/{user_id}", response_model=User, response_model_exclude={"password"})
-async def get_user(user_id: str, current_user: User = Depends(get_current_user)):
+async def get_user(user_id: PyObjectId, current_user: User = Depends(get_current_user)):
     """Retrieve a user from the database by id"""
     if not is_admin(current_user) and current_user.id != user_id:
         raise HTTPException(status_code=403, detail="Not authorized to view this user")
@@ -93,7 +92,7 @@ async def get_all_users(current_user: User = Depends(get_current_user)):
 
 
 @router.put("/update/{user_id}", response_model=User, response_model_exclude={"password"})
-async def update_user(user_id: str, updated_info: UpdateUser, current_user: User = Depends(get_current_user)):
+async def update_user(user_id: PyObjectId, updated_info: UpdateUser, current_user: User = Depends(get_current_user)):
     """Update a user in the database by id"""
     user_info_to_update = {k: v for k, v in updated_info.dict().items() if v is not None}
 
@@ -106,7 +105,6 @@ async def update_user(user_id: str, updated_info: UpdateUser, current_user: User
     if not is_admin(current_user) and current_user.id != user_id:
         raise HTTPException(status_code=403, detail="Not authorized to update this user")
 
-    user_id = ObjectId(user_id)
     old_user = user_collection.find_one_and_update({"_id": user_id}, {"$set": user_info_to_update})
     if old_user is None:
         raise HTTPException(status_code=404, detail=f"User with id {user_id} not found")
@@ -116,12 +114,11 @@ async def update_user(user_id: str, updated_info: UpdateUser, current_user: User
 
 
 @router.delete("/delete/{user_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_user(user_id: str, current_user: User = Depends(get_current_user)):
+async def delete_user(user_id: PyObjectId, current_user: User = Depends(get_current_user)):
     """Delete a user from the database by id"""
     if not is_admin(current_user) and current_user.id != user_id:
         raise HTTPException(status_code=403, detail="Not authorized to delete this user")
 
-    user_id = ObjectId(user_id)
     user = user_collection.find_one_and_delete({"_id": user_id})
 
     if user is None:

--- a/models/cards.py
+++ b/models/cards.py
@@ -3,14 +3,14 @@ from typing import List
 from bson.objectid import ObjectId
 from pydantic import BaseModel, Field
 
-from models.py_object_id import PyObjectId
+from .py_object_id import PyObjectId
 
 
 class Card(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     front_text: str = Field(...)
     back_text: str = Field(...)
-    lesson_ids: List[str] = Field(...)
+    lesson_ids: List[PyObjectId] = Field(...)
 
     class Config:
         arbitrary_types_allowed = True

--- a/models/lessons.py
+++ b/models/lessons.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from bson.objectid import ObjectId
 from pydantic import BaseModel, Field
 from models.py_object_id import PyObjectId
@@ -9,6 +9,8 @@ class Lesson(BaseModel):
     title: str = Field(...)
     section_id: str = Field(...)
     card_ids: List[str] = Field(default_factory=list)
+    section_id: Optional[PyObjectId] = Field(default=None)
+    card_ids: List[PyObjectId] = Field(default=[])
 
     class Config:
         arbitrary_types_allowed = True

--- a/models/lessons.py
+++ b/models/lessons.py
@@ -1,16 +1,19 @@
 from typing import List, Optional
 from bson.objectid import ObjectId
-from pydantic import BaseModel, Field
-from models.py_object_id import PyObjectId
-
+from pydantic import BaseModel, Field, validator
+from .py_object_id import PyObjectId
 
 class Lesson(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     title: str = Field(...)
-    section_id: str = Field(...)
-    card_ids: List[str] = Field(default_factory=list)
     section_id: Optional[PyObjectId] = Field(default=None)
     card_ids: List[PyObjectId] = Field(default=[])
+
+    @validator('section_id', pre=True, always=True)
+    def validate_section_id(cls, v):
+        if v == "":
+            return None
+        return v
 
     class Config:
         arbitrary_types_allowed = True

--- a/models/py_object_id.py
+++ b/models/py_object_id.py
@@ -11,7 +11,7 @@ class PyObjectId(ObjectId):
     def validate(cls, v):
         if not ObjectId.is_valid(v):
             raise ValueError('Invalid object id')
-        return str(v)
+        return ObjectId(v)
 
     @classmethod
     def __modify_schema__(cls, field_schema):

--- a/models/sections.py
+++ b/models/sections.py
@@ -1,12 +1,12 @@
 from typing import List
 from pydantic import BaseModel, Field
-from models.py_object_id import PyObjectId
+from .py_object_id import PyObjectId
 from bson.objectid import ObjectId
 
 class Section(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     name: str = Field(...)
-    lesson_ids: List[PyObjectId] = Field(default_factory=list)
+    lesson_ids: List[PyObjectId] = Field(default=[])
 
     class Config:
         arbitrary_types_allowed = True

--- a/models/update_card.py
+++ b/models/update_card.py
@@ -2,11 +2,12 @@ from typing import Optional, List
 
 from pydantic import BaseModel
 
+from .py_object_id import PyObjectId
 
 class UpdateCard(BaseModel):
     front_text: Optional[str] = None
     back_text: Optional[str] = None
-    lesson_ids: Optional[List[str]] = None
+    lesson_ids: Optional[List[PyObjectId]] = None
 
     class Config:
         arbitrary_types_allowed = True

--- a/models/update_lesson.py
+++ b/models/update_lesson.py
@@ -1,12 +1,20 @@
 from typing import Optional, List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
+from .py_object_id import PyObjectId
 
 # define a pydantic model to update a lesson
 class UpdateLesson(BaseModel):
-    name: Optional[str] = None
-    cards: Optional[List[str]] = None
+    title: Optional[str] = None
+    section_id: Optional[PyObjectId] = None
+    card_ids: Optional[List[PyObjectId]] = None
+
+    @validator('section_id', pre=True, always=True)
+    def validate_section_id(cls, v):
+        if v == "":
+            return None
+        return v
 
     class Config:
         arbitrary_types_allowed = True

--- a/models/update_lesson.py
+++ b/models/update_lesson.py
@@ -21,7 +21,8 @@ class UpdateLesson(BaseModel):
         allow_population_by_field_name = True
         schema_extra = {
             "example": {
-                "name": "Hello",
-                "cards": ["5f9f1b9b9c9d1c0b8c8b9c9d"]
+                "title": "Hello",
+                "section_id": "5f9f1b9b9c9d1c0b8c8b9c9d",
+                "card_ids": ["5f9f1b9b9c9d1c0b8c8b9c9d"]
             }
         }

--- a/models/update_section.py
+++ b/models/update_section.py
@@ -1,0 +1,19 @@
+from typing import Optional, List
+
+from pydantic import BaseModel
+
+from .py_object_id import PyObjectId
+
+class UpdateSection(BaseModel):
+    name: Optional[str] = None
+    lesson_ids: Optional[List[PyObjectId]] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+        allow_population_by_field_name = True
+        schema_extra = {
+            "example": {
+                "name": "Hello",
+                "lesson_ids": ["5f9f1b9b9c9d1c0b8c8b9c9d"]
+            }
+        }

--- a/models/update_user.py
+++ b/models/update_user.py
@@ -4,6 +4,8 @@ from bson.objectid import ObjectId
 from passlib.context import CryptContext
 from pydantic import BaseModel
 
+from .py_object_id import PyObjectId
+
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
@@ -11,7 +13,7 @@ class UpdateUser(BaseModel):
     username: Optional[str] = None
     password: Optional[str] = None
     roles: Optional[List[str]] = None
-    completed_lessons: Optional[List[str]] = None
+    completed_lessons: Optional[List[PyObjectId]] = None
 
     class Config:
         allow_population_by_field_name = True

--- a/models/users.py
+++ b/models/users.py
@@ -4,7 +4,7 @@ from bson.objectid import ObjectId
 from passlib.context import CryptContext
 from pydantic import BaseModel, Field
 
-from models.py_object_id import PyObjectId
+from .py_object_id import PyObjectId
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -13,7 +13,7 @@ class User(BaseModel):
     username: str = Field(...)
     password: str = Field(...)
     roles: List[str] = Field(default=["user"])
-    completed_lessons: List[str] = Field(default=[])
+    completed_lessons: List[PyObjectId] = Field(default=[])
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
- All models now use PyObjectId for IDs related to other models
- All models now properly auto-encode (provided the request data is in the right format)
- The PyObjectId model now correctly auto-encodes and returns a string for object ids in requests
- Bugs for the Section, Lesson, and Card routes now work have been fixed