### PR TITLE
Update lesson model with content and category

### DIFF
--- a/api/lessons.py
+++ b/api/lessons.py
@@ -49,6 +49,21 @@ async def create_lesson(lesson: Lesson):
     return lesson
 
 
+@router.get("/by-category/{category}")
+async def get_lessons_by_category(category: str):
+    """Retrieve all lessons from the database by category"""
+    if category not in ["grammar", "vocabulary", "kanji"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Category must be one of 'grammar', 'vocabulary', or 'kanji'",
+        )
+    lessons = lesson_collection.find({"category": category})
+
+    return [Lesson(**lesson) for lesson in lessons] or HTTPException(
+        status_code=404, detail=f"No lessons found for category {category}"
+    )
+
+
 @router.get("/{lesson_id}")
 async def get_lesson(lesson_id: PyObjectId):
     """Retrieve a lesson from the database by id"""

--- a/models/lessons.py
+++ b/models/lessons.py
@@ -10,7 +10,9 @@ class Lesson(BaseModel):
     id: PyObjectId = Field(default_factory=PyObjectId, alias="_id")
     title: str = Field(...)
     section_id: Optional[PyObjectId] = Field(default=None)
-    card_ids: List[PyObjectId] = Field(default=[])
+    card_ids: Optional[List[PyObjectId]] = Field(default=[])
+    content: Optional[str] = Field(default="")  # This will be markdown content
+    category: str = Field(...)
 
     @validator("section_id", pre=True, always=True)
     def validate_section_id(cls, v):
@@ -27,5 +29,9 @@ class Lesson(BaseModel):
                 "title": "Basic Grammar",
                 "section_id": "5f9f1b9b9c9d1c0b8c8b9c9d",
                 "card_ids": ["5f9f1b9b9c9d1c0b8c8b9c9d"],
+                "content": "#This is some markdown content for a lesson on basic grammar in Japanese #"
+                "##This is a subheading"
+                "This is some more content",
+                "category": "grammar",  # This could be grammar, vocabulary, or kanji
             }
         }


### PR DESCRIPTION
### Brief Description
In this pull request, I updated the Lesson model to include fields for markdown content and for categories. 
### Changes
- There is now two more fields in the Lesson model
  - `content` for markdown content in Grammar/Reading lessons
  - ` category` to categorize lessons (i.e. as "Grammar", "Vocabulary", etc.)
- There is now a route for searching for lessons by a specific category
- Not necessarily reflected in the files, but there's now an index in the database for lesson categories